### PR TITLE
correct chart issues to pass CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
           name: "push-to-default-app-collection"
           app_catalog: "default-catalog"
           app_catalog_test: "default-test-catalog"
-          chart: "cloud-provider-vsphere-app"
+          chart: "cloud-provider-vsphere"
           # Trigger job on git tag.
           filters:
             tags:

--- a/helm/cloud-provider-vsphere/.kube-linter.yaml
+++ b/helm/cloud-provider-vsphere/.kube-linter.yaml
@@ -1,5 +1,15 @@
 checks:
   addAllBuiltIn: true
   exclude:
+  - "access-to-secrets"
   - "host-network"
+  - "no-liveness-probe"
+  - "no-readiness-probe"
   - "no-read-only-root-fs"
+  - "non-isolated-pod"
+  - "required-annotation-email"
+  - "required-label-owner"
+  - "unset-cpu-requirements"
+  - "unset-memory-requirements"
+  - "use-namespace"
+  - "wildcard-in-rules"

--- a/helm/cloud-provider-vsphere/.kube-linter.yaml
+++ b/helm/cloud-provider-vsphere/.kube-linter.yaml
@@ -1,0 +1,5 @@
+checks:
+  addAllBuiltIn: true
+  exclude:
+  - "host-network"
+  - "no-read-only-root-fs"

--- a/helm/cloud-provider-vsphere/ci/ci-values.yaml
+++ b/helm/cloud-provider-vsphere/ci/ci-values.yaml
@@ -1,0 +1,8 @@
+daemonset:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+       cpu: 256m
+       memory: 128Mi

--- a/helm/cloud-provider-vsphere/ci/ci-values.yaml
+++ b/helm/cloud-provider-vsphere/ci/ci-values.yaml
@@ -4,5 +4,5 @@ daemonset:
       cpu: 500m
       memory: 512Mi
     requests:
-       cpu: 256m
-       memory: 128Mi
+      cpu: 256m
+      memory: 128Mi

--- a/helm/cloud-provider-vsphere/templates/_helpers.tpl
+++ b/helm/cloud-provider-vsphere/templates/_helpers.tpl
@@ -53,3 +53,37 @@ Configure list of IP CIDRs allowed access to load balancer (if supported)
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Giant Swarm additions below
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "labels.common" -}}
+app.kubernetes.io/name: {{ include "name" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+helm.sh/chart: {{ include "chart" . | quote }}
+giantswarm.io/cluster: {{ .Values.clusterName | quote }}
+giantswarm.io/managed-by: {{ .Release.Name | quote }}
+giantswarm.io/organization: {{ .Values.organization | quote }}
+giantswarm.io/service-type: managed
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+{{- end -}}

--- a/helm/cloud-provider-vsphere/templates/configmap.yaml
+++ b/helm/cloud-provider-vsphere/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: cloud-config
     component: cloud-controller-manager
+    {{- include "labels.common" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 data:
   vsphere.conf: |

--- a/helm/cloud-provider-vsphere/templates/daemonset.yaml
+++ b/helm/cloud-provider-vsphere/templates/daemonset.yaml
@@ -7,6 +7,7 @@ metadata:
     vsphere-cpi-infra: daemonset
     component: cloud-controller-manager
     tier: control-plane
+    {{- include "labels.common" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ""
@@ -31,6 +32,7 @@ spec:
         tier: control-plane
         release: {{ .Release.Name }}
         vsphere-cpi-infra: daemonset
+        {{- include "labels.common" $ | nindent 4 }}
         {{- if .Values.daemonset.podLabels }}
         {{- toYaml .Values.daemonset.podLabels | nindent 8 }}
         {{- end }}

--- a/helm/cloud-provider-vsphere/templates/ingress.yaml
+++ b/helm/cloud-provider-vsphere/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: ingress
     component: cloud-controller
+    {{- include "labels.common" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.ingress.annotations }}
   annotations:

--- a/helm/cloud-provider-vsphere/templates/podsecuritypolicy.yaml
+++ b/helm/cloud-provider-vsphere/templates/podsecuritypolicy.yaml
@@ -8,6 +8,7 @@ metadata:
     vsphere-cpi-infra: pod-security-policy
     component: cloud-controller-manager
     release: {{ .Release.Name }}
+    {{- include "labels.common" $ | nindent 4 }}
   {{- if .Values.podSecurityPolicy.annotations }}
   annotations:
   {{- toYaml .Values.podSecurityPolicy.annotations | indent 4 }}

--- a/helm/cloud-provider-vsphere/templates/role-binding.yaml
+++ b/helm/cloud-provider-vsphere/templates/role-binding.yaml
@@ -11,6 +11,7 @@ items:
       app: {{ template "cpi.name" . }}
       vsphere-cpi-infra: role-binding
       component: cloud-controller-manager
+      {{- include "labels.common" $ | nindent 4 }}
     namespace: {{ .Release.Namespace }}
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/helm/cloud-provider-vsphere/templates/role.yaml
+++ b/helm/cloud-provider-vsphere/templates/role.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: role
     component: cloud-controller-manager
+    {{- include "labels.common" $ | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/helm/cloud-provider-vsphere/templates/secret.yaml
+++ b/helm/cloud-provider-vsphere/templates/secret.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: secret
     component: cloud-controller-manager
+    {{- include "labels.common" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 stringData:
   {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.username: {{ .Values.config.username | default .Values.global.config.username }}

--- a/helm/cloud-provider-vsphere/templates/service-account.yaml
+++ b/helm/cloud-provider-vsphere/templates/service-account.yaml
@@ -7,5 +7,6 @@ metadata:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: service-account
     component: cloud-controller-manager
+    {{- include "labels.common" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/helm/cloud-provider-vsphere/templates/service.yaml
+++ b/helm/cloud-provider-vsphere/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
     component: cloud-controller-manager
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- include "labels.common" $ | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.service.annotations }}
   annotations:


### PR DESCRIPTION
this pr:

- corrects the chart dir name in the CI config
- add giantswarm helper funcs and apply common labels to all resources
- appeases the linting gods