### PR TITLE
ensure configmap mount name matches the configmap name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure configmap is mounted correctly.
+
 ## [1.2.0] - 2022-05-17
 
 ### Fixed

--- a/helm/cloud-provider-vsphere/templates/daemonset.yaml
+++ b/helm/cloud-provider-vsphere/templates/daemonset.yaml
@@ -100,4 +100,4 @@ spec:
       volumes:
         - name: vsphere-config-volume
           configMap:
-            name: cloud-config
+            name: vsphere-cloud-config


### PR DESCRIPTION
This PR:

- fixes an upstream bug where different names are used to reference the same configmap

### Checklist

- [x] Update changelog in CHANGELOG.md.
