### PR TITLE
Typo in the CircleCI badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/cloud-provider-vsphere-app-app.svg?style=shield)](https://circleci.com/gh/giantswarm/cloud-provider-vsphere-app-app)
+[![CircleCI](https://circleci.com/gh/giantswarm/cloud-provider-vsphere-app.svg?style=shield)](https://circleci.com/gh/giantswarm/cloud-provider-vsphere-app)
 
 # cloud-provider-vsphere chart
 


### PR DESCRIPTION
I also needed some PR to verify that the app is not being pushed to the test catalog, this change still makes a sense because there is a typo there.


Signed-off-by: Jiri Kremser <jiri.kremser@gmail.com>
