### PR TITLE
Add missing network policy for CSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.1] - 2023-03-14
+### Fixed
 
-## [1.4.0] - 2023-03-14
+- Add network policy for CSI controller.
+
+## [1.3.1] - 2023-03-14
 
 ### Changed
 

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/networkpolicy-vsphere-csi.yml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/networkpolicy-vsphere-csi.yml
@@ -1,0 +1,16 @@
+# Allow csi-vcd-controllerplugin to access world (vsphere api)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: csi-allow-egress
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: vsphere-csi-controller
+  egress:
+  - {}
+  policyTypes:
+  - Egress


### PR DESCRIPTION
CSI controller needs to access Vsphere API and it requires this network policy.


### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
