### PR TITLE
Add missing network policies

### DIFF
--- a/config/kube-vip-cloud-provider/overwrites/templates/npols.yaml
+++ b/config/kube-vip-cloud-provider/overwrites/templates/npols.yaml
@@ -1,0 +1,46 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kubevip-cp-talk-to-apiserver
+  namespace: {{ .Release.Namespace | default "kube-system" }}
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kube-vip-cloud-provider.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          component: kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kubevip-cp-talk-to-apiserver
+  namespace: {{ .Release.Namespace | default "kube-system" }}
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "kube-vip-cloud-provider.selectorLabels" . | nindent 6 }}
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+---

--- a/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/templates/npols.yaml
+++ b/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/templates/npols.yaml
@@ -1,0 +1,46 @@
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kubevip-cp-talk-to-apiserver
+  namespace: {{ .Release.Namespace | default "kube-system" }}
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kube-vip-cloud-provider.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          component: kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kubevip-cp-talk-to-apiserver
+  namespace: {{ .Release.Namespace | default "kube-system" }}
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "kube-vip-cloud-provider.selectorLabels" . | nindent 6 }}
+  egress:
+    - toEntities:
+      - kube-apiserver
+      toPorts:
+        - ports:
+          - port: "443"
+            protocol: TCP
+          - port: "6443"
+            protocol: TCP
+---


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2815

otherwise:

```
kube-vip-cloud-provider:
   E1107 11:57:54.845328       1 leaderelection.go:330] error retrieving resource lock kube-system/kube-vip-cloud-controller: Get "https://172.31.0.1:443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-vip-cloud-controller?timeout=5s": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)

```