### PR TITLE
Update image tags for 1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Pull images from Azure CR.
+- Update image tags for 1.26 compatibility.
 
 ## [1.6.0] - 2024-02-27
 

--- a/helm/cloud-provider-vsphere/README.md
+++ b/helm/cloud-provider-vsphere/README.md
@@ -140,9 +140,11 @@ $ helm install vsphere-cpi \
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart.
 
-### Image tags
+### Image tags compatibility matrix
 
-vSphere CPI offers a multitude of [tags](https://github.com/kubernetes/cloud-provider-vsphere/releases) for the various components used in this chart.
+* Container Storage Interface: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html#vSphere%20Container%20Storage%20Plug-in%203.1.x
+
+* Cloud Provider Interface: https://github.com/kubernetes/cloud-provider-vsphere?tab=readme-ov-file#compatibility-with-kubernetes
 
 ## Developer Releasing Guide
 

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/values.yaml
@@ -54,8 +54,6 @@ serviceAccount:
 # Daemonset configuration
 daemonset:
   annotations: {}
-  image: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  tag: v1.26.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdline:

--- a/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/values.yaml
@@ -5,10 +5,7 @@
 replicasCount: 1
 
 image:
-  repository: kubevip/kube-vip-cloud-provider
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.0.4"
 
 resources:
   requests:

--- a/helm/cloud-provider-vsphere/charts/kube-vip/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/kube-vip/values.yaml
@@ -3,10 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: ghcr.io/kube-vip/kube-vip
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.5.11"
 
 config:
   address: ""

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
@@ -10,38 +10,6 @@ config:
 
 controllerDeployment:
   replicas: 1
-  csiAttacher:
-    image: docker.io/giantswarm/csi-attacher
-    tag: v3.5.0
-  csiResizer:
-    image: docker.io/giantswarm/csi-resizer
-    tag: v1.5.0
-  csiController:
-    image: docker.io/giantswarm/csi-vsphere-driver
-    tag: v2.7.1
-  livenessProbe:
-    image: docker.io/giantswarm/livenessprobe
-    tag: v2.7.0
-  syncer:
-    image: docker.io/giantswarm/csi-vsphere-syncer
-    tag: v2.7.1
-  csiProvisioner:
-    image: docker.io/giantswarm/csi-provisioner
-    tag: v3.2.1
-  csiSnapshotter:
-    image: docker.io/giantswarm/csi-snapshotter
-    tag: v6.0.1
-
-nodeDaemonset:
-  nodeDriverRegistrar:
-    image: docker.io/giantswarm/csi-node-driver-registrar
-    tag: v2.5.1
-  csiNode:
-    image: docker.io/giantswarm/csi-vsphere-driver
-    tag: v2.7.1
-  livenessProbe:
-    image: docker.io/giantswarm/livenessprobe
-    tag: v2.7.0
 
 storageClass:
   enabled: true

--- a/helm/cloud-provider-vsphere/values.yaml
+++ b/helm/cloud-provider-vsphere/values.yaml
@@ -17,6 +17,7 @@ global:
 cloud-provider-for-vsphere:
   daemonset:
     image: gsoci.azurecr.io/giantswarm/cpi-vsphere-manager
+    tag: v1.26.2
 
 kube-vip:
   enabled: true
@@ -24,7 +25,7 @@ kube-vip:
     vip_interface: "ens192"
   image:
     repository: gsoci.azurecr.io/giantswarm/kube-vip
-    tag: "v0.6.3"
+    tag: v0.8.0
   nameOverride: kube-vip-svc-lb
   tolerations:
   - effect: NoSchedule
@@ -40,7 +41,7 @@ kube-vip-cloud-provider:
   cidrGlobal: ""
   image:
     repository: gsoci.azurecr.io/giantswarm/kube-vip-cloud-provider
-    tag: "v0.0.4"
+    tag: v0.0.9
   nameOverride: kube-vip-cloud-provider
 
 vsphere-csi-driver:
@@ -56,26 +57,36 @@ vsphere-csi-driver:
   controllerDeployment:
     csiAttacher:
       image: gsoci.azurecr.io/giantswarm/csi-attacher
+      tag: v4.3.0
     csiResizer:
       image: gsoci.azurecr.io/giantswarm/csi-resizer
+      tag: v1.8.0
     csiController:
       image: gsoci.azurecr.io/giantswarm/csi-vsphere-driver
+      tag: v3.1.2
     livenessProbe:
       image: gsoci.azurecr.io/giantswarm/livenessprobe
+      tag: v2.10.0
     syncer:
       image: gsoci.azurecr.io/giantswarm/csi-vsphere-syncer
+      tag: v3.1.2
     csiProvisioner:
       image: gsoci.azurecr.io/giantswarm/csi-provisioner
+      tag: v3.5.0
     csiSnapshotter:
       image: gsoci.azurecr.io/giantswarm/csi-snapshotter
+      tag: v6.2.2
 
   nodeDaemonset:
     csiNode:
       image: gsoci.azurecr.io/giantswarm/csi-vsphere-driver
+      tag: v3.1.2
     livenessProbe:
       image: gsoci.azurecr.io/giantswarm/livenessprobe
+      tag: v2.10.0
     nodeDriverRegistrar:
       image: gsoci.azurecr.io/giantswarm/csi-node-driver-registrar
+      tag: v2.8.0
 
   podSecurityContext:
     runAsNonRoot: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3467

CSI compatibility with 1.26: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html#vSphere%20Container%20Storage%20Plug-in%203.1.x

CPI compatibility with 1.26: https://github.com/kubernetes/cloud-provider-vsphere?tab=readme-ov-file#compatibility-with-kubernetes
