### PR TITLE
Update for k8s 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 This app contains CPI and CSI for CAPV clusters. 
 
+| Cloud Provider vSphere app | Kubernetes version |
+| -------------------------- | ------------------ |
+| 1.9.x | 1.29.x |
+| 1.8.x | 1.28.x |
+| 1.7.x | 1.27.x |
+
 ## How to install
 
 - Clone this repository. 

--- a/config/cloud-provider-for-vsphere/overwrites/Chart.yaml
+++ b/config/cloud-provider-for-vsphere/overwrites/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.27.0
+appVersion: 1.28.0
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: cloud-provider-for-vsphere
-version: 1.27.0
+version: 1.28.0
 keywords:
   - vsphere
   - vmware

--- a/hack/update-cpi-chart.sh
+++ b/hack/update-cpi-chart.sh
@@ -10,7 +10,7 @@ cd "$base_dir"
 
 "./hack/clone-git-repo.sh" \
     "/kubernetes/cloud-provider-vsphere" \
-    "release-1.27" \
+    "release-1.28" \
     "cloud-provider-vsphere"
 
 rm -Rf "$chart_dir"

--- a/hack/update-cpi-chart.sh
+++ b/hack/update-cpi-chart.sh
@@ -10,7 +10,7 @@ cd "$base_dir"
 
 "./hack/clone-git-repo.sh" \
     "/kubernetes/cloud-provider-vsphere" \
-    "release-1.28" \
+    "v1.28.1" \
     "cloud-provider-vsphere"
 
 rm -Rf "$chart_dir"

--- a/helm/cloud-provider-vsphere/Chart.yaml
+++ b/helm/cloud-provider-vsphere/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
     email: team-rocket@giantswarm.io
 dependencies:
   - name: cloud-provider-for-vsphere
-    version: 1.27.0
+    version: 1.28.0
   - name: vsphere-csi-driver
     version: 3.2.0
   - name: kube-vip

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.27.0
+appVersion: 1.28.0
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: cloud-provider-for-vsphere
-version: 1.27.0
+version: 1.28.0
 keywords:
   - vsphere
   - vmware

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/README.md
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/README.md
@@ -149,7 +149,7 @@ helm repo add vsphere-cpi https://kubernetes.github.io/cloud-provider-vsphere
 helm repo update
 
 # Package CPI Chart
-VERSION=1.27.0
+VERSION=1.28.0
 cd charts
 helm package vsphere-cpi --version $VERSION --app-version $VERSION
 

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/values.yaml
@@ -12,50 +12,44 @@ config:
   region: "k8s-region"
   zone: "k8s-zone"
   thumbprint: ""
-
   secret:
     # Specifies whether Secret should be created from config values
     create: true
     # The name of the Secret referred to in the vsphere-cloud-config ConfigMap
     # If your Kubernetes platform provides this secret, set create to false and adjust the secret name
     name: vsphere-cloud-secret
-
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 podSecurityPolicy:
   enabled: false
   annotations: {}
-    # Specify pod annotations
-    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
-    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
-    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
-    #
-    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-    # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
-    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
-
+  # Specify pod annotations
+  # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+  # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+  # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+  #
+  # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+  # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 # Run containers to have security context. Default is 'nobody' (65534/65534) in distroless
 securityContext:
   enabled: true
   runAsUser: 1001
   fsGroup: 1001
-
 # RBAC configuration
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
-
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
   # The name of the ServiceAccount to use.
   name: cloud-controller-manager
-
 # Daemonset configuration
 daemonset:
   annotations: {}
   image: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  tag: v1.27.0
+  tag: v1.28.1
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdline:
@@ -67,12 +61,12 @@ daemonset:
     additionalParams: {}
   replicaCount: 1
   resources: {}
-    # limits:
-    #   cpu: 500m
-    #   memory: 512Mi
-    # requests:
-    #    cpu: 256m
-    #    memory: 128Mi
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #    cpu: 256m
+  #    memory: 128Mi
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/helm/cloud-provider-vsphere/values.yaml
+++ b/helm/cloud-provider-vsphere/values.yaml
@@ -16,7 +16,7 @@ global:
 
 cloud-provider-for-vsphere:
   daemonset:
-    image: gsoci.azurecr.io/giantswarm/cpi-vsphere-manager
+    image: gsoci.azurecr.io/giantswarm/cloud-provider-vsphere
 
 kube-vip:
   enabled: true


### PR DESCRIPTION
CSI: [3.2.0](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html) compatible for 1.27 to 1.29. Already using that verion.
CPI: [1.28](https://github.com/kubernetes/cloud-provider-vsphere?tab=readme-ov-file#compatibility-with-kubernetes)