### PR TITLE
Update cpi-csi 1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update vSphere CPI to `1.30` for Kubernetes 1.30 compatibility.
+
 ## [1.9.0] - 2024-07-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This app contains CPI and CSI for CAPV clusters.
 
 | Cloud Provider vSphere app | Kubernetes version |
 | -------------------------- | ------------------ |
+| 1.10.x | 1.30.x |
 | 1.9.x | 1.29.x |
 | 1.8.x | 1.28.x |
 | 1.7.x | 1.27.x |

--- a/config/cloud-provider-for-vsphere/overwrites/Chart.yaml
+++ b/config/cloud-provider-for-vsphere/overwrites/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.29.0
+appVersion: 1.30.1
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: cloud-provider-for-vsphere
-version: 1.29.0
+version: 1.30.1
 keywords:
   - vsphere
   - vmware

--- a/config/vsphere-csi-driver/overwrites/Chart.yaml
+++ b/config/vsphere-csi-driver/overwrites/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vsphere-csi-driver
-appVersion: 3.2.0
-version: 3.2.0
+appVersion: 3.3.0
+version: 3.3.0
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 home: https://github.com/giantswarm/cloud-provider-vsphere-app
 keywords:

--- a/hack/update-cpi-chart.sh
+++ b/hack/update-cpi-chart.sh
@@ -10,7 +10,7 @@ cd "$base_dir"
 
 "./hack/clone-git-repo.sh" \
     "/kubernetes/cloud-provider-vsphere" \
-    "vsphere-cpi-chart-1.29.0" \
+    "v1.30.1" \
     "cloud-provider-vsphere"
 
 rm -Rf "$chart_dir"

--- a/hack/update-csi-chart.sh
+++ b/hack/update-csi-chart.sh
@@ -10,7 +10,7 @@ cd "$base_dir"
 
 "./hack/clone-git-repo.sh" \
   "kubernetes-sigs/vsphere-csi-driver" \
-  "v3.2.0" \
+  "v3.3.0" \
   "vsphere-csi-driver"
 
 rm -Rf "$chart_dir"

--- a/helm/cloud-provider-vsphere/Chart.yaml
+++ b/helm/cloud-provider-vsphere/Chart.yaml
@@ -15,9 +15,9 @@ maintainers:
     email: team-rocket@giantswarm.io
 dependencies:
   - name: cloud-provider-for-vsphere
-    version: 1.29.0
+    version: 1.30.1
   - name: vsphere-csi-driver
-    version: 3.2.0
+    version: 3.3.0
   - name: kube-vip
     version: 0.6.1
     condition: kube-vip.enabled

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.29.0
+appVersion: 1.30.1
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: cloud-provider-for-vsphere
-version: 1.29.0
+version: 1.30.1
 keywords:
   - vsphere
   - vmware

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/README.md
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/README.md
@@ -149,7 +149,7 @@ helm repo add vsphere-cpi https://kubernetes.github.io/cloud-provider-vsphere
 helm repo update
 
 # Package CPI Chart
-VERSION=1.29.0
+VERSION=1.30.0
 cd charts
 helm package vsphere-cpi --version $VERSION --app-version $VERSION
 

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/values.yaml
@@ -55,7 +55,7 @@ serviceAccount:
 daemonset:
   annotations: {}
   image: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  tag: v1.29.0
+  tag: v1.30.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdline:

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vsphere-csi-driver
-appVersion: 3.2.0
-version: 3.2.0
+appVersion: 3.3.0
+version: 3.3.0
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 home: https://github.com/giantswarm/cloud-provider-vsphere-app
 keywords:

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/apps_v1_daemonset_vsphere-csi-node.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/apps_v1_daemonset_vsphere-csi-node.yaml
@@ -25,7 +25,7 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
-        image: gsoci.azurecr.io/giantswarm/csi-node-driver-registrar:v2.10.0
+        image: gsoci.azurecr.io/giantswarm/csi-node-driver-registrar:v2.10.1
         livenessProbe:
           exec:
             command:
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
           value: "1"
-        image: gsoci.azurecr.io/giantswarm/csi-vsphere-driver:v3.2.0
+        image: gsoci.azurecr.io/giantswarm/csi-vsphere-driver:v3.3.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/apps_v1_deployment_vsphere-csi-controller.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/apps_v1_deployment_vsphere-csi-controller.yaml
@@ -22,6 +22,18 @@ spec:
         role: vsphere-csi
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/controlplane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -45,7 +57,7 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: gsoci.azurecr.io/giantswarm/csi-attacher:v4.5.0
+          image: gsoci.azurecr.io/giantswarm/csi-attacher:v4.5.1
           name: csi-attacher
           volumeMounts:
             - mountPath: /csi
@@ -68,7 +80,7 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: gsoci.azurecr.io/giantswarm/csi-resizer:v1.10.0
+          image: gsoci.azurecr.io/giantswarm/csi-resizer:v1.10.1
           name: csi-resizer
           volumeMounts:
             - mountPath: /csi
@@ -97,13 +109,11 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
-            - name: GODEBUG
-              value: x509sha1=1,tlsmaxrsasize=16384
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: gsoci.azurecr.io/giantswarm/csi-vsphere-driver:v3.2.0
+          image: gsoci.azurecr.io/giantswarm/csi-vsphere-driver:v3.3.0
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
@@ -161,13 +171,11 @@ spec:
               value: "100"
             - name: INCLUSTER_CLIENT_BURST
               value: "100"
-            - name: GODEBUG
-              value: x509sha1=1,tlsmaxrsasize=16384
             - name: CSI_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: gsoci.azurecr.io/giantswarm/csi-vsphere-syncer:v3.2.0
+          image: gsoci.azurecr.io/giantswarm/csi-vsphere-syncer:v3.3.0
           imagePullPolicy: Always
           name: vsphere-syncer
           ports:
@@ -196,7 +204,7 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: gsoci.azurecr.io/giantswarm/csi-provisioner:v4.0.0
+          image: gsoci.azurecr.io/giantswarm/csi-provisioner:v4.0.1
           name: csi-provisioner
           volumeMounts:
             - mountPath: /csi
@@ -218,7 +226,7 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: gsoci.azurecr.io/giantswarm/csi-snapshotter:v7.0.1
+          image: gsoci.azurecr.io/giantswarm/csi-snapshotter:v7.0.2
           name: csi-snapshotter
           volumeMounts:
             - mountPath: /csi
@@ -228,8 +236,6 @@ spec:
                 {{- . | toYaml | nindent 12 }}
               {{- end }}
       dnsPolicy: Default
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: vsphere-csi-controller
       tolerations:


### PR DESCRIPTION
CSI: [3.3.0](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html) compatible for 1.28 to 1.30. Already using that verion.
CPI: [1.30](https://github.com/kubernetes/cloud-provider-vsphere?tab=readme-ov-file#compatibility-with-kubernetes)