### PR TITLE
configurable storage class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make default storage class configurable.
+
 ## [1.10.0] - 2024-07-08
 
 ### Changed

--- a/config/vsphere-csi-driver/overwrites/templates/storage.k8s.io_v1_storage_class_default.yaml
+++ b/config/vsphere-csi-driver/overwrites/templates/storage.k8s.io_v1_storage_class_default.yaml
@@ -5,33 +5,16 @@ apiVersion: storage.k8s.io/v1
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  {{- if .delete.isDefault }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-  {{- end }}
-  name: csi-vsphere-sc-delete
+  name: csi-vsphere-sc-default
 provisioner: csi.vsphere.vmware.com
-reclaimPolicy: Delete
+reclaimPolicy: {{ .reclaimPolicy }}
 allowVolumeExpansion: true
 parameters:
-  storagepolicyname: {{ .delete.vcdStorageProfileName | quote }}
-  csi.storage.k8s.io/fstype: {{ .delete.fileSystem }}
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  labels:
-    {{- include "labels.common" $ | nindent 4 }}
-  {{- if .retain.isDefault }}
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+  {{- if .storageProfileName }}
+  storagepolicyname: {{ .storageProfileName | quote }}
   {{- end }}
-  name: csi-vsphere-sc-retain
-provisioner: csi.vsphere.vmware.com
-reclaimPolicy: Retain
-allowVolumeExpansion: true
-parameters:
-  storagepolicyname: {{ .retain.vcdStorageProfileName | quote }}
-  csi.storage.k8s.io/fstype: {{ .retain.fileSystem }}
+  csi.storage.k8s.io/fstype: {{ .fileSystem }}
 {{- end }}
 {{- end }}

--- a/config/vsphere-csi-driver/overwrites/values.yaml
+++ b/config/vsphere-csi-driver/overwrites/values.yaml
@@ -10,14 +10,9 @@ config:
 
 storageClass:
   enabled: true
-  delete:
-    isDefault: true
-    vcdStorageProfileName: "vSAN Default Storage Policy"
-    fileSystem: "ext4"
-  retain:
-    isDefault: false
-    vcdStorageProfileName: "vSAN Default Storage Policy"
-    fileSystem: "ext4"
+  reclaimPolicy: "Delete"
+  fileSystem: "ext4"
+  # storageProfileName: "vSAN Default Storage Policy"
 
 internalFeatureStates:
   topologyPreferentialDatastores:

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/storage.k8s.io_v1_storage_class_default.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/storage.k8s.io_v1_storage_class_default.yaml
@@ -5,11 +5,9 @@ apiVersion: storage.k8s.io/v1
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  {{- if .isDefault }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-  {{- end }}
-  name: csi-vsphere-sc-delete
+  name: csi-vsphere-sc-default
 provisioner: csi.vsphere.vmware.com
 reclaimPolicy: {{ .reclaimPolicy }}
 allowVolumeExpansion: true

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/storage.k8s.io_v1_storage_class_default.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/templates/storage.k8s.io_v1_storage_class_default.yaml
@@ -5,33 +5,18 @@ apiVersion: storage.k8s.io/v1
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  {{- if .delete.isDefault }}
+  {{- if .isDefault }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   {{- end }}
   name: csi-vsphere-sc-delete
 provisioner: csi.vsphere.vmware.com
-reclaimPolicy: Delete
+reclaimPolicy: {{ .reclaimPolicy }}
 allowVolumeExpansion: true
 parameters:
-  storagepolicyname: {{ .delete.vcdStorageProfileName | quote }}
-  csi.storage.k8s.io/fstype: {{ .delete.fileSystem }}
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  labels:
-    {{- include "labels.common" $ | nindent 4 }}
-  {{- if .retain.isDefault }}
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
+  {{- if .storageProfileName }}
+  storagepolicyname: {{ .storageProfileName | quote }}
   {{- end }}
-  name: csi-vsphere-sc-retain
-provisioner: csi.vsphere.vmware.com
-reclaimPolicy: Retain
-allowVolumeExpansion: true
-parameters:
-  storagepolicyname: {{ .retain.vcdStorageProfileName | quote }}
-  csi.storage.k8s.io/fstype: {{ .retain.fileSystem }}
+  csi.storage.k8s.io/fstype: {{ .fileSystem }}
 {{- end }}
 {{- end }}

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
@@ -11,8 +11,8 @@ config:
 storageClass:
   enabled: true
   reclaimPolicy: "Delete"
-  # storageProfileName: "vSAN Default Storage Policy"
   fileSystem: "ext4"
+  # storageProfileName: "vSAN Default Storage Policy"
 
 internalFeatureStates:
   topologyPreferentialDatastores:

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
@@ -10,14 +10,10 @@ config:
 
 storageClass:
   enabled: true
-  delete:
-    isDefault: true
-    vcdStorageProfileName: "vSAN Default Storage Policy"
-    fileSystem: "ext4"
-  retain:
-    isDefault: false
-    vcdStorageProfileName: "vSAN Default Storage Policy"
-    fileSystem: "ext4"
+  isDefault: true
+  reclaimPolicy: "Delete"
+  # storageProfileName: "vSAN Default Storage Policy"
+  fileSystem: "ext4"
 
 internalFeatureStates:
   topologyPreferentialDatastores:

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/values.yaml
@@ -10,7 +10,6 @@ config:
 
 storageClass:
   enabled: true
-  isDefault: true
   reclaimPolicy: "Delete"
   # storageProfileName: "vSAN Default Storage Policy"
   fileSystem: "ext4"


### PR DESCRIPTION
This pr adds the capability to specify a storage policy or none for the default vSphere csi storage class. Setting no storage policy is required in some cases.

This is a proposal to only create (or not) one single default storage class with the cluster chart.  As a result I made the `reclaimPolicy` configurable along with the vSphere storage policy.

The idea is to offer the customer the ability to easily create a default SC, other SCs can be created manually.

Consumed by https://github.com/giantswarm/cluster-vsphere/pull/264

Towards https://github.com/giantswarm/roadmap/issues/3626