### PR TITLE
Renovate and more

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -8,7 +8,7 @@ YQ = ./bin/yq
 YQ_VERSION := 4.31.2
 
 .PHONY: all
-all: update-cpi-chart update-csi-chart apply-custom-patches-for-csi update-kubevip-chart update-kubevip-cloud-provider-chart
+all: update-cpi-chart update-csi-chart apply-custom-patches-for-csi update-kubevip-chart update-kubevip-cloud-provider-chart increase-chart-version
 	@$(call say,Sync has been done ✓)
 
 .PHONY: update-cpi-chart
@@ -39,6 +39,11 @@ update-kubevip-cloud-provider-chart:
 	@$(call say,Kubevip cloud provider helm chart)
 	./hack/update-kubevip-cloud-provider-chart.sh
 	./hack/common-labels-injector.sh kube-vip-cloud-provider
+
+.PHONY: increase-chart-version
+increase-chart-version:
+	@$(call say,Increase parent chart SemVer version)
+	./hack/increase-chart-version.sh
 
 $(KUSTOMIZE): ## Download kustomize locally if necessary.
 	@$(call say,Download Kustomize)

--- a/README.md
+++ b/README.md
@@ -44,85 +44,43 @@ CSI doesn't have a helm chart so we created the chart based on the manifest file
 
 It is planned to automate chart creation with `kustomize` to be able to update easily and to be able to track our custom changes properly.
 
-## How to update the charts automatically
+## Information on our charts
 
-### kube-vip
+### vSphere Cloud Provider
 
-- In the `kube-vip/helm-charts` upstream repo, browse to [charts/kube-vip/Chart.yaml](https://github.com/kube-vip/helm-charts/blob/main/charts/kube-vip/Chart.yaml) (`kube-vip` folder, **not** `kube-vip-cloud-provider`) and switch branch to the latest `kube-vip-x.y.z` tag (e.g. `kube-vip-0.6.1`).
-- Edit [update-kubevip-chart.sh](hack/update-kubevip-chart.sh) here and change the branch value under `./hack/clone-git-repo.sh` to reflect the branch version. For instance:
+Nothing exotic about this, we just grab the upstream chart.
 
-``` sh
-"./hack/clone-git-repo.sh" \
-    "kube-vip/helm-charts" \
-    "kube-vip-0.6.1" \
-    "kube-vip"
-```
-
-- Change `version` and `appVersion` fields in our [Chart.yaml overwrite](config/kube-vip/overwrites/Chart.yaml) to match the ones in upstream `Chart.yaml` (check you're on the right branch).
-- In `Chart.yaml`, `appVersion` is used as kube-vip image tag. If you require a different tag than what is set upstream, change it to the tag you need from the [upstream kube-vip tags](https://github.com/kube-vip/kube-vip/tags) in the [Chart.yaml overwrite](config/kube-vip/overwrites/Chart.yaml).
-
-### kube-vip-cloud-provider
-
-- In the `kube-vip/helm-charts` upstream repo, browse to [charts/kube-vip-cloud-provider/Chart.yaml](https://github.com/kube-vip/helm-charts/blob/main/charts/kube-vip-cloud-provider/Chart.yaml) (`kube-vip-cloud-provider` folder, **not** `kube-vip`) and switch branch to the latest `kube-vip-cloud-provider-x.y.z` tag (e.g. `kube-vip-cloud-provider-0.2.2`).
-- Edit [update-kubevip-cloud-provider-chart.sh](hack/update-kubevip-cloud-provider-chart.sh) here and change the branch value under `./hack/clone-git-repo.sh` to reflect the branch version. For instance:
-
-``` sh
-"./hack/clone-git-repo.sh" \
-    "kube-vip/helm-charts" \
-    "kube-vip-cloud-provider-0.2.2" \
-    "kube-vip-cloud-provider"
-```
-
-- Change `version` and `appVersion` fields in our [Chart.yaml overwrite](config/kube-vip/overwrites/Chart.yaml) to match the ones in upstream `Chart.yaml` (check you're on the right branch).
-- In `Chart.yaml`, `appVersion` is used as kube-vip image tag. If you require a different tag than what is set upstream, change it to the tag you need from the [upstream kube-vip-cloud-provider tag](https://github.com/kube-vip/kube-vip-cloud-provider/tags) in the [Chart.yaml overwrite](config/kube-vip-cloud-provider/overwrites/Chart.yaml).
+> [!NOTE]
+> The vSphere Cloud Provider versions are aligned with Kubernetes versions for support (e.g. CPI v1.27.0 for Kubernetes v1.27) so make sure the CSI is also aligned when merging.
 
 ### vSphere CSI driver
 
 > [!NOTE]
 > There is no upstream Helm chart for the CSI, we generate it from the manifests and we apply customizations. There are a few overwrites and patches in the `/config/vsphere-csi-driver` folder.
+> Find the latest CSI version that is compatible with the Kubernetes version of the cluster it will run in. You will find this in the [Release Notes](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html). For instance, vSphere CSI `v3.2.0` is compatible with Kubernetes `1.27` to `1.29`. (You can check the tag exists in the [upstream repo](https://github.com/kubernetes-sigs/vsphere-csi-driver/tags)). Make sure the CPI is also aligned when merging.
 
-- First off, find the latest CSI version that is compatible with the Kubernetes version of the cluster it will run in. You will find this in the [Release Notes](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html). For instance, vSphere CSI `v3.2.0` is compatible with Kubernetes `1.27` to `1.29`. (You can check the tag exists in the [upstream repo](https://github.com/kubernetes-sigs/vsphere-csi-driver/tags))
-- Edit [update-csi-chart.sh](hack/update-csi-chart.sh) here and change the branch value under `./hack/clone-git-repo.sh` to reflect the branch version. For instance:
-
-``` sh
-"./hack/clone-git-repo.sh" \
-  "kubernetes-sigs/vsphere-csi-driver" \
-  "v3.2.0" \
-  "vsphere-csi-driver"
-```
-
-- Then Adjust `version` and `appVersion` in the [Chart.yaml overwrite](config/vsphere-csi-driver/overwrites/Chart.yaml). For instance:
-
-``` yaml
-appVersion: 3.2.0
-version: 3.2.0
-```
-
-### vSphere Cloud Provider
+### kube-vip
 
 > [!NOTE]
-> The vSphere Cloud Provider versions are aligned with Kubernetes versions for support (e.g. CPI v1.27.0 for Kubernetes v1.27).
+> New versions of the `kube-vip` Helm chart are released with `kube-vip-x.y.z` in the `kube-vip/helm-charts` repo (same repo as `kube-vip-cloud-provider`).
 
-- In the [upstream repo](https://github.com/kubernetes/cloud-provider-vsphere/tree/release-1.27), look for the branch of the version to update to (`release-x.yy`).
-- Edit [update-cpi-chart.sh](hack/update-cpi-chart.sh) here and change the branch value under `./hack/clone-git-repo.sh` to reflect the branch version. For instance:
+Note that the upstream `kube-vip` Helm chart isn't well maintained so we use the latest chart but also the latest kube-vip tags.
+In `Chart.yaml`, `version` corresponds to the chart's release and `appVersion` is used as kube-vip image tag.
 
-``` sh
-"./hack/clone-git-repo.sh" \
-    "/kubernetes/cloud-provider-vsphere" \
-    "release-1.27" \
-    "cloud-provider-vsphere"
-```
+### kube-vip-cloud-provider
 
-- Then Adjust `version` and `appVersion` in the [Chart.yaml overwrite](config/cloud-provider-for-vsphere/overwrites/Chart.yaml). For instance:
+> [!NOTE]
+> New versions of the `kube-vip-cloud-provider` Helm chart are released with `kube-vip-cloud-provider-x.y.z` in the `kube-vip/helm-charts` repo (same repo as `kube-vip`).
 
-``` yaml
-appVersion: 1.27.0
-version: 1.27.0
-```
+Note that the upstream `kube-vip-cloud-provider` Helm chart isn't well maintained so we use the latest chart but also the latest kube-vip-cloud-provider tags.
+In `Chart.yaml`, `version` corresponds to the chart's release and `appVersion` is used as kube-vip-cloud-provider image tag.
 
-### Update parent chart's dependencies
+## How to update the charts with Renovate
 
-- Update each chart's version to use in the parent `Chart.yaml` in [templates/Chart.yaml](templates/Chart.yaml).
+Renovate updates `version` and `appVersion` fields in `Chart.yaml` files located in `./config/xxx/overrides`. This is the file that is then used to template the actual sub-charts.
+
+> [!CAUTION]
+> Only release this app if you are sure that both `vSphere Cloud Provider` and `vSphere CSI driver` support the same Kubernetes version.
 
 ### Update the charts
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,17 @@ Source: https://github.com/kube-vip/helm-charts/tree/kube-vip-cloud-provider-0.2
 Note that the upstream `kube-vip-cloud-provider` Helm chart isn't well maintained so we use the latest chart but also the latest kube-vip-cloud-provider tags.
 In `Chart.yaml`, `version` corresponds to the chart's release and `appVersion` is used as kube-vip-cloud-provider image tag.
 
-## How to update the charts with Renovate
+## Information on Renovate in this repo
 
 Renovate updates `version` and `appVersion` fields in `Chart.yaml` files located in `./config/xxx/overrides`. This is the file that is then used to template the actual sub-charts.
 
 > [!CAUTION]
 > Only release this app if you are sure that both `vSphere Cloud Provider` and `vSphere CSI driver` support the same Kubernetes version.
 
-### Update the charts
+### Process of updating the charts
 
-- Let Renovate open PRs.
-- Run `make all`.
+- Renovate opens a PR (let's say on branch `renovate/kube-vip-helm-charts-0.x`).
+- Pull the branch on your local: `git pull && git checkout renovate/kube-vip-helm-charts-0.x`
+- Run the scripts to update the charts: `make all`
+- If everythig is ok, push the changes back to the branch and test the PR.
 - Check the diffs.

--- a/README.md
+++ b/README.md
@@ -11,55 +11,28 @@ This app contains CPI and CSI for CAPV clusters.
 | 1.8.x | 1.28.x |
 | 1.7.x | 1.27.x |
 
-## How to install
-
-- Clone this repository. 
-  ```sh
-  git clone https://github.com/giantswarm/cloud-provider-vsphere-app.git
-  ```
-- Go into helm chart directory.
-  ```sh
-  cd cloud-provider-vsphere-app/helm/cloud-provider-vsphere
-  ```
-- Fill the missing values in values.yaml file.
-  ```sh
-  $EDITOR values.yaml
-  ```
-- Install the chart.
-  ```sh
-  helm install cloud-provider-vsphere -n kube-system -f values.yaml .
-  ```
-
-## Source of charts
-
-The sources of charts are as below.
-
-- CPI: https://github.com/kubernetes/cloud-provider-vsphere/tree/master/charts/vsphere-cpi
-- CSI: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/manifests/vanilla/vsphere-csi-driver.yaml
-- kube-vip: https://github.com/kube-vip/helm-charts/commit/8c5b2d353082372ac8698885c1dab01efeebec98
-- kubevip-cloud-provider: https://github.com/kube-vip/helm-charts/tree/kube-vip-cloud-provider-0.2.2/charts/kube-vip-cloud-provider
-
-CPI's helm chart is not as mature as we want so we customized it.
-CSI doesn't have a helm chart so we created the chart based on the manifest file.
-
-It is planned to automate chart creation with `kustomize` to be able to update easily and to be able to track our custom changes properly.
-
 ## Information on our charts
 
 ### vSphere Cloud Provider
 
-Nothing exotic about this, we just grab the upstream chart.
+Source: https://github.com/kubernetes/cloud-provider-vsphere/tree/master/charts/vsphere-cpi
+
+Nothing really exotic about this, we just grab the upstream chart.
 
 > [!NOTE]
 > The vSphere Cloud Provider versions are aligned with Kubernetes versions for support (e.g. CPI v1.27.0 for Kubernetes v1.27) so make sure the CSI is also aligned when merging.
 
 ### vSphere CSI driver
 
+Source: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/manifests/vanilla/vsphere-csi-driver.yaml
+
 > [!NOTE]
 > There is no upstream Helm chart for the CSI, we generate it from the manifests and we apply customizations. There are a few overwrites and patches in the `/config/vsphere-csi-driver` folder.
 > Find the latest CSI version that is compatible with the Kubernetes version of the cluster it will run in. You will find this in the [Release Notes](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/rn/vmware-vsphere-container-storage-plugin-30-release-notes/index.html). For instance, vSphere CSI `v3.2.0` is compatible with Kubernetes `1.27` to `1.29`. (You can check the tag exists in the [upstream repo](https://github.com/kubernetes-sigs/vsphere-csi-driver/tags)). Make sure the CPI is also aligned when merging.
 
 ### kube-vip
+
+Source: https://github.com/kube-vip/helm-charts/commit/8c5b2d353082372ac8698885c1dab01efeebec98
 
 > [!NOTE]
 > New versions of the `kube-vip` Helm chart are released with `kube-vip-x.y.z` in the `kube-vip/helm-charts` repo (same repo as `kube-vip-cloud-provider`).
@@ -68,6 +41,8 @@ Note that the upstream `kube-vip` Helm chart isn't well maintained so we use the
 In `Chart.yaml`, `version` corresponds to the chart's release and `appVersion` is used as kube-vip image tag.
 
 ### kube-vip-cloud-provider
+
+Source: https://github.com/kube-vip/helm-charts/tree/kube-vip-cloud-provider-0.2.2/charts/kube-vip-cloud-provider
 
 > [!NOTE]
 > New versions of the `kube-vip-cloud-provider` Helm chart are released with `kube-vip-cloud-provider-x.y.z` in the `kube-vip/helm-charts` repo (same repo as `kube-vip`).

--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ Renovate updates `version` and `appVersion` fields in `Chart.yaml` files located
 
 ### Update the charts
 
+- Let Renovate open PRs.
 - Run `make all`.
 - Check the diffs.

--- a/config/cloud-provider-for-vsphere/overwrites/Chart.yaml
+++ b/config/cloud-provider-for-vsphere/overwrites/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
+# repo: kubernetes/cloud-provider-vsphere
 appVersion: 1.30.1
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: cloud-provider-for-vsphere
+# repo: kubernetes/cloud-provider-vsphere
 version: 1.30.1
 keywords:
   - vsphere

--- a/config/kube-vip-cloud-provider/overwrites/Chart.yaml
+++ b/config/kube-vip-cloud-provider/overwrites/Chart.yaml
@@ -12,15 +12,15 @@ description: A Helm chart for kube-vip cloud provider
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+#* This is the upstream chart version which is released as a specific tag in the same repo as `kube-vip`.
+#* Renovate below watches releases that match `kube-vip-cloud-provider-x.y.z`.
+# renovate-kube-vip-cloud-provider: kube-vip/helm-charts
 version: 0.2.2
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# *** GIANT SWARM : Bump version to fix CVE. ***
+#* This is the app's version of the application being deployed.
+#* It overwrites the value of the upstream chart above which isn't well maintained.
+#* Renovate watches for standard versioning as the releases are normal in this repo.
+# repo: kube-vip/kube-vip-cloud-provider
 appVersion: v0.0.5
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png

--- a/config/kube-vip/overwrites/Chart.yaml
+++ b/config/kube-vip/overwrites/Chart.yaml
@@ -12,14 +12,15 @@ description: A Helm chart for kube-vip
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+#* This is the upstream chart version which is released as a specific tag in the same repo as `kube-vip-cloud-provider`.
+#* Renovate below watches releases that match `kube-vip-x.y.z`.
+# renovate-kube-vip: kube-vip/helm-charts
 version: 0.6.1
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
+#* This is the app's version of the application being deployed.
+#* It overwrites the value of the upstream chart above which isn't well maintained.
+#* Renovate watches for standard versioning as the releases are normal in this repo.
+# repo: kube-vip/kube-vip
 appVersion: v0.8.0
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png

--- a/config/vsphere-csi-driver/overwrites/Chart.yaml
+++ b/config/vsphere-csi-driver/overwrites/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: vsphere-csi-driver
+# repo: kubernetes-sigs/vsphere-csi-driver
 appVersion: 3.3.0
+# repo: kubernetes-sigs/vsphere-csi-driver
 version: 3.3.0
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 home: https://github.com/giantswarm/cloud-provider-vsphere-app

--- a/hack/increase-chart-version.sh
+++ b/hack/increase-chart-version.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 set -x
-
+env
 if [[ -z "${CIRCLECI}" ]]; then
 # Not running in CircleCI
 

--- a/hack/increase-chart-version.sh
+++ b/hack/increase-chart-version.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 set -x
-env
-if [[ -z "${CIRCLECI}" ]]; then
+
+if [[ -z "${GITHUB_ACTIONS}" ]]; then
 # Not running in CircleCI
 
 chart_file="helm/cloud-provider-vsphere/Chart.yaml"

--- a/hack/increase-chart-version.sh
+++ b/hack/increase-chart-version.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+chart_file="helm/cloud-provider-vsphere/Chart.yaml"
+current_version=$(cat $chart_file | grep "^version:")
+current_version=$(echo "${current_version#*:}" | xargs)
+
+update_version() {
+    new_version=$1
+    yq e -i ".version = \"$new_version\" | .appVersion = \"$new_version\"" "$chart_file"
+    echo "Chart version updated: $current_version -> $new_version"
+}
+
+read -p "Do you want to update the chart's version? [n] No, [m] Minor, [p] Patch: " choice
+
+case $choice in
+"n")
+    echo "No version update."
+    ;;
+"m")
+    new_version=$(echo $current_version | awk -F. '{$2++; printf "%d.%d.%d",$1,$2,$3}')
+    update_version "$new_version"
+    ;;
+"p")
+    new_version=$(echo $current_version | awk -F. '{$3++; printf "%d.%d.%d",$1,$2,$3}')
+    update_version "$new_version"
+    ;;
+*)
+    echo "Invalid choice. Please enter n, m, or p."
+    ;;
+esac

--- a/hack/increase-chart-version.sh
+++ b/hack/increase-chart-version.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
+set -x
+
+if [[ -z "${CIRCLECI}" ]]; then
+# Not running in CircleCI
 
 chart_file="helm/cloud-provider-vsphere/Chart.yaml"
-current_version=$(cat $chart_file | grep "^version:")
-current_version=$(echo "${current_version#*:}" | xargs)
+
+current_version=$(yq e '.version' $chart_file)
 
 update_version() {
     new_version=$1
@@ -30,3 +34,5 @@ case $choice in
     echo "Invalid choice. Please enter n, m, or p."
     ;;
 esac
+
+fi

--- a/hack/increase-chart-version.sh
+++ b/hack/increase-chart-version.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 set -x
 
 if [[ -z "${GITHUB_ACTIONS}" ]]; then
-# Not running in CircleCI
+# Not running in a GH action
 
 chart_file="helm/cloud-provider-vsphere/Chart.yaml"
 
@@ -35,4 +35,6 @@ case $choice in
     ;;
 esac
 
+else
+echo "Running in GH Action - skipping interactive task"
 fi

--- a/hack/update-cpi-chart.sh
+++ b/hack/update-cpi-chart.sh
@@ -9,13 +9,12 @@ chart_dir="./helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere"
 cd "$base_dir"
 
 # The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
-VERSION=$(cat config/cloud-provider-for-vsphere/overwrites/Chart.yaml | grep "^version:")
-VERSION=$(echo "${VERSION#*:}" | xargs)
+VERSION=$(yq e '.version' "config/cloud-provider-for-vsphere/overwrites/Chart.yaml")
 
 "./hack/clone-git-repo.sh" \
-    "/kubernetes/cloud-provider-vsphere" \
-    "v$VERSION" \
-    "cloud-provider-vsphere"
+  "/kubernetes/cloud-provider-vsphere" \
+  "v$VERSION" \
+  "cloud-provider-vsphere"
 
 rm -Rf "$chart_dir"
 mkdir "$chart_dir"

--- a/hack/update-cpi-chart.sh
+++ b/hack/update-cpi-chart.sh
@@ -8,9 +8,13 @@ chart_dir="./helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere"
 
 cd "$base_dir"
 
+# The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
+VERSION=$(cat config/cloud-provider-for-vsphere/overwrites/Chart.yaml | grep "^version:")
+VERSION=$(echo "${VERSION#*:}" | xargs)
+
 "./hack/clone-git-repo.sh" \
     "/kubernetes/cloud-provider-vsphere" \
-    "v1.30.1" \
+    "v$VERSION" \
     "cloud-provider-vsphere"
 
 rm -Rf "$chart_dir"

--- a/hack/update-csi-chart.sh
+++ b/hack/update-csi-chart.sh
@@ -9,8 +9,7 @@ KUSTOMIZE="${1:-kustomize}"
 cd "$base_dir"
 
 # The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
-VERSION=$(cat config/vsphere-csi-driver/overwrites/Chart.yaml | grep "^version:")
-VERSION=$(echo "${VERSION#*:}" | xargs)
+VERSION=$(yq e '.version' "config/vsphere-csi-driver/overwrites/Chart.yaml")
 
 "./hack/clone-git-repo.sh" \
   "kubernetes-sigs/vsphere-csi-driver" \

--- a/hack/update-csi-chart.sh
+++ b/hack/update-csi-chart.sh
@@ -8,9 +8,13 @@ KUSTOMIZE="${1:-kustomize}"
 
 cd "$base_dir"
 
+# The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
+VERSION=$(cat config/vsphere-csi-driver/overwrites/Chart.yaml | grep "^version:")
+VERSION=$(echo "${VERSION#*:}" | xargs)
+
 "./hack/clone-git-repo.sh" \
   "kubernetes-sigs/vsphere-csi-driver" \
-  "v3.3.0" \
+  "v$VERSION" \
   "vsphere-csi-driver"
 
 rm -Rf "$chart_dir"

--- a/hack/update-kubevip-chart.sh
+++ b/hack/update-kubevip-chart.sh
@@ -9,13 +9,12 @@ chart_dir="./helm/cloud-provider-vsphere/charts/kube-vip"
 cd "$base_dir"
 
 # The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
-VERSION=$(cat config/kube-vip/overwrites/Chart.yaml | grep "^version:")
-VERSION=$(echo "${VERSION#*:}" | xargs)
+VERSION=$(yq e '.version' "config/kube-vip/overwrites/Chart.yaml")
 
 "./hack/clone-git-repo.sh" \
-    "kube-vip/helm-charts" \
-    "kube-vip-$VERSION" \
-    "kube-vip"
+  "kube-vip/helm-charts" \
+  "kube-vip-$VERSION" \
+  "kube-vip"
 
 rm -Rf "$chart_dir"
 

--- a/hack/update-kubevip-chart.sh
+++ b/hack/update-kubevip-chart.sh
@@ -8,9 +8,13 @@ chart_dir="./helm/cloud-provider-vsphere/charts/kube-vip"
 
 cd "$base_dir"
 
+# The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
+VERSION=$(cat config/kube-vip/overwrites/Chart.yaml | grep "^version:")
+VERSION=$(echo "${VERSION#*:}" | xargs)
+
 "./hack/clone-git-repo.sh" \
     "kube-vip/helm-charts" \
-    "kube-vip-0.6.1" \
+    "kube-vip-$VERSION" \
     "kube-vip"
 
 rm -Rf "$chart_dir"

--- a/hack/update-kubevip-cloud-provider-chart.sh
+++ b/hack/update-kubevip-cloud-provider-chart.sh
@@ -9,13 +9,12 @@ chart_dir="./helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider"
 cd "$base_dir"
 
 # The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
-VERSION=$(cat config/kube-vip-cloud-provider/overwrites/Chart.yaml | grep "^version:")
-VERSION=$(echo "${VERSION#*:}" | xargs)
+VERSION=$(yq e '.version' "config/kube-vip-cloud-provider/overwrites/Chart.yaml")
 
 "./hack/clone-git-repo.sh" \
-    "kube-vip/helm-charts" \
-    "kube-vip-cloud-provider-$VERSION" \
-    "kube-vip-cloud-provider"
+  "kube-vip/helm-charts" \
+  "kube-vip-cloud-provider-$VERSION" \
+  "kube-vip-cloud-provider"
 
 rm -Rf "$chart_dir"
 

--- a/hack/update-kubevip-cloud-provider-chart.sh
+++ b/hack/update-kubevip-cloud-provider-chart.sh
@@ -8,9 +8,13 @@ chart_dir="./helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider"
 
 cd "$base_dir"
 
+# The goal here is to control versions only from Chart.yaml overrides with Renovate and grab that version here.
+VERSION=$(cat config/kube-vip-cloud-provider/overwrites/Chart.yaml | grep "^version:")
+VERSION=$(echo "${VERSION#*:}" | xargs)
+
 "./hack/clone-git-repo.sh" \
     "kube-vip/helm-charts" \
-    "kube-vip-cloud-provider-0.2.2" \
+    "kube-vip-cloud-provider-$VERSION" \
     "kube-vip-cloud-provider"
 
 rm -Rf "$chart_dir"

--- a/helm/cloud-provider-vsphere/Chart.yaml
+++ b/helm/cloud-provider-vsphere/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 version: 1.11.0
-appVersion: 0.0.1
+appVersion: 1.11.0
 name: cloud-provider-vsphere
 description: A Helm chart for cloud-provider-vsphere with CPI and CSI
 engine: gotpl

--- a/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/cloud-provider-for-vsphere/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
+# repo: kubernetes/cloud-provider-vsphere
 appVersion: 1.30.1
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: cloud-provider-for-vsphere
+# repo: kubernetes/cloud-provider-vsphere
 version: 1.30.1
 keywords:
   - vsphere

--- a/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/Chart.yaml
@@ -12,15 +12,17 @@ description: A Helm chart for kube-vip cloud provider
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+#* This is the upstream chart version which is released as a specific tag in the same repo as `kube-vip`.
+#* Renovate below watches releases that match `kube-vip-cloud-provider-x.y.z`.
+
+# renovate-kube-vip-cloud-provider: kube-vip/helm-charts
 version: 0.2.2
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# *** GIANT SWARM : Bump version to fix CVE. ***
+#* This is the app's version of the application being deployed.
+#* It overwrites the value of the upstream chart above which isn't well maintained.
+#* Renovate watches for standard versioning as the releases are normal in this repo.
+
+# repo: kube-vip/kube-vip-cloud-provider
 appVersion: v0.0.5
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png

--- a/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/kube-vip-cloud-provider/Chart.yaml
@@ -14,14 +14,12 @@ type: application
 
 #* This is the upstream chart version which is released as a specific tag in the same repo as `kube-vip`.
 #* Renovate below watches releases that match `kube-vip-cloud-provider-x.y.z`.
-
 # renovate-kube-vip-cloud-provider: kube-vip/helm-charts
 version: 0.2.2
 
 #* This is the app's version of the application being deployed.
 #* It overwrites the value of the upstream chart above which isn't well maintained.
 #* Renovate watches for standard versioning as the releases are normal in this repo.
-
 # repo: kube-vip/kube-vip-cloud-provider
 appVersion: v0.0.5
 

--- a/helm/cloud-provider-vsphere/charts/kube-vip/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/kube-vip/Chart.yaml
@@ -14,14 +14,12 @@ type: application
 
 #* This is the upstream chart version which is released as a specific tag in the same repo as `kube-vip-cloud-provider`.
 #* Renovate below watches releases that match `kube-vip-x.y.z`.
-
 # renovate-kube-vip: kube-vip/helm-charts
 version: 0.6.1
 
 #* This is the app's version of the application being deployed.
 #* It overwrites the value of the upstream chart above which isn't well maintained.
 #* Renovate watches for standard versioning as the releases are normal in this repo.
-
 # repo: kube-vip/kube-vip
 appVersion: v0.8.0
 

--- a/helm/cloud-provider-vsphere/charts/kube-vip/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/kube-vip/Chart.yaml
@@ -12,14 +12,17 @@ description: A Helm chart for kube-vip
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+#* This is the upstream chart version which is released as a specific tag in the same repo as `kube-vip-cloud-provider`.
+#* Renovate below watches releases that match `kube-vip-x.y.z`.
+
+# renovate-kube-vip: kube-vip/helm-charts
 version: 0.6.1
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
+#* This is the app's version of the application being deployed.
+#* It overwrites the value of the upstream chart above which isn't well maintained.
+#* Renovate watches for standard versioning as the releases are normal in this repo.
+
+# repo: kube-vip/kube-vip
 appVersion: v0.8.0
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png

--- a/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/Chart.yaml
+++ b/helm/cloud-provider-vsphere/charts/vsphere-csi-driver/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: vsphere-csi-driver
+# repo: kubernetes-sigs/vsphere-csi-driver
 appVersion: 3.3.0
+# repo: kubernetes-sigs/vsphere-csi-driver
 version: 3.3.0
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 home: https://github.com/giantswarm/cloud-provider-vsphere-app

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,10 @@
   "customManagers": [
       {
         "customType": "regex",
-        "fileMatch": ["config/.+\\.y[a]?ml$"],
+        "fileMatch": [
+          "config/.+\\.y[a]?ml$",
+          "helm/cloud-provider-vsphere/Chart.yaml"
+        ],
         "matchStrings": [
           "renovate-kube-vip: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
           "renovate-kube-vip: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n"
@@ -24,7 +27,10 @@
       },
       {
         "customType": "regex",
-        "fileMatch": ["config/.+\\.y[a]?ml$"],
+        "fileMatch": [
+          "config/.+\\.y[a]?ml$",
+          "helm/cloud-provider-vsphere/Chart.yaml"
+        ],
         "matchStrings": [
           "renovate-kube-vip-cloud-provider: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
           "renovate-kube-vip-cloud-provider: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n"

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,5 +6,27 @@
   "prBodyNotes": [
     "Please do not merge directly",
     "Follow update procedure in the [README](https://github.com/giantswarm/cloud-provider-vsphere-app?tab=readme-ov-file#how-to-update-the-charts-automatically)."
+  ],
+  "customManagers": [
+      {
+        "customType": "regex",
+        "fileMatch": ["kube-vip/.+\\.y[a]?ml$"],
+        "matchStrings": [
+          "renovate-kube-vip: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
+          "renovate-kube-vip: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n"
+        ],
+        "datasourceTemplate": "github-releases",
+        "extractVersionTemplate": "^\"?kube-vip-?(?<version>.*)\"?$"
+      },
+      {
+        "customType": "regex",
+        "fileMatch": ["kube-vip/.+\\.y[a]?ml$"],
+        "matchStrings": [
+          "renovate-kube-vip-cloud-provider: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
+          "renovate-kube-vip-cloud-provider: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n"
+        ],
+        "datasourceTemplate": "github-releases",
+        "extractVersionTemplate": "^\"?kube-vip-cloud-provider-?(?<version>.*)\"?$"
+      }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,10 +7,14 @@
     "Please do not merge directly",
     "Follow update procedure in the [README](https://github.com/giantswarm/cloud-provider-vsphere-app?tab=readme-ov-file#how-to-update-the-charts-automatically)."
   ],
+  "ignorePaths": [
+    "helm",
+    "hack"
+  ],
   "customManagers": [
       {
-        "customType": "regex",
-        "fileMatch": ["kube-vip/.+\\.y[a]?ml$"],
+        "customType": "regex",g
+        "fileMatch": ["config/.+\\.y[a]?ml$"],
         "matchStrings": [
           "renovate-kube-vip: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
           "renovate-kube-vip: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n"
@@ -20,7 +24,7 @@
       },
       {
         "customType": "regex",
-        "fileMatch": ["kube-vip/.+\\.y[a]?ml$"],
+        "fileMatch": ["config/.+\\.y[a]?ml$"],
         "matchStrings": [
           "renovate-kube-vip-cloud-provider: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
           "renovate-kube-vip-cloud-provider: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n"

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,7 +13,7 @@
   ],
   "customManagers": [
       {
-        "customType": "regex",g
+        "customType": "regex",
         "fileMatch": ["config/.+\\.y[a]?ml$"],
         "matchStrings": [
           "renovate-kube-vip: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,7 @@
     "github>giantswarm/renovate-presets:default.json5",
   ],
   "prBodyNotes": [
-    "Please do not merge directly",
+    ":warning: Please do not merge directly :warning:",
     "Follow update procedure in the [README](https://github.com/giantswarm/cloud-provider-vsphere-app?tab=readme-ov-file#how-to-update-the-charts-automatically)."
   ],
   "ignorePaths": [


### PR DESCRIPTION
This PR adds Renovate to the chart.

Renovate only watches the `Chart.yaml` files in the `./config` folders with custom managers to work with the weird release tags upstream.

The .sh scripts collect the versions (updated by renovate as explained above) and continues as before.

I also added a small script at the end to ask the user if they want to update the chart's version number as we never do it otherwise.

The new method for updating this chart should be as follows (explained in README):

- Renovate opens a PR.
- git checkout to the PR's branch
- run `make all`

> [!NOTE]
> If we want to do things right (even though unlikely that it causes issues), we only release if both the CPI and CSI versions officially support the same Kubernetes version (and update the table in the README would be nice).