### PR TITLE
reduce scope of kubernetes manager

### DIFF
--- a/helm/cloud-provider-vsphere/Chart.yaml
+++ b/helm/cloud-provider-vsphere/Chart.yaml
@@ -15,12 +15,16 @@ maintainers:
     email: team-rocket@giantswarm.io
 dependencies:
   - name: cloud-provider-for-vsphere
+    # repo: kubernetes/cloud-provider-vsphere
     version: 1.30.1
   - name: vsphere-csi-driver
+    # repo: kubernetes-sigs/vsphere-csi-driver
     version: 3.3.0
   - name: kube-vip
+    # renovate-kube-vip: kube-vip/helm-charts
     version: 0.6.1
     condition: kube-vip.enabled
   - name: kube-vip-cloud-provider
+    # renovate-kube-vip-cloud-provider: kube-vip/helm-charts
     version: 0.2.2
     condition: kube-vip-cloud-provider.enabled

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,10 +7,14 @@
     ":warning: Please do not merge directly :warning:",
     "Follow update procedure in the [README](https://github.com/giantswarm/cloud-provider-vsphere-app?tab=readme-ov-file#how-to-update-the-charts-automatically)."
   ],
-  "ignorePaths": [
-    "helm",
-    "hack"
-  ],
+  "kubernetes": {
+    "ignorePaths": [
+      // We don't want to watch the K8s manifests directly.
+      "helm",
+      "config",
+      "hack"
+    ]
+  },
   "customManagers": [
       {
         "customType": "regex",


### PR DESCRIPTION
I need the custom managers to watch `helm/cloud-provider-vsphere/Chart.yaml` but not the kubernetes manager.

So I _think_ this should do it.